### PR TITLE
[Forwardport] Resolve Knockout non-unique elements id in console error

### DIFF
--- a/app/code/Magento/Checkout/view/frontend/web/template/billing-address/form.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/billing-address/form.html
@@ -21,6 +21,6 @@
                 </label>
             </div>
             <!-- /ko -->
-        </fieldset >
+        </fieldset>
     </form>
 </div>

--- a/app/code/Magento/Checkout/view/frontend/web/template/billing-address/form.html
+++ b/app/code/Magento/Checkout/view/frontend/web/template/billing-address/form.html
@@ -9,7 +9,7 @@
     <!-- ko template: getTemplate() --><!-- /ko -->
     <!--/ko-->
     <form data-bind="attr: {'data-hasrequired': $t('* Required Fields')}">
-        <fieldset id="billing-new-address-form" class="fieldset address">
+        <fieldset data-bind="attr: { id:'billing-new-address-form-'+index, value:index}" class="fieldset address">
             <!-- ko foreach: getRegion('additional-fieldsets') -->
             <!-- ko template: getTemplate() --><!-- /ko -->
             <!--/ko-->
@@ -21,6 +21,6 @@
                 </label>
             </div>
             <!-- /ko -->
-        </fieldset>
+        </fieldset >
     </form>
 </div>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15349
When enabling more than one payment methods from admin, It is giving an error in the console "Found elements with non-unique id billing-address-form "

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#15348: 
2. Issue titleMultiple Payment Methods Enabled is giving error in console "Found 3 Elements with non - unique Id"

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Login to Admin Panel > Sales> Payment Methods
2. Enable more than one of Magento payment methods for checkout
3. Add a product to the cart, press F12 to check the console log in the browser

### Expected Result
It should not show any error in the console

### Actual result
![screenshot from 2018-05-19 14-10-36](https://user-images.githubusercontent.com/33098216/40266901-43a36ae8-5b71-11e8-8d83-ecdcc23bbebf.png)

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
