### PR TITLE
[Forwardport] Prevent multiple add-to-cart initializations in case of ajax loaded product listing

### DIFF
--- a/app/code/Magento/Catalog/view/frontend/web/js/catalog-add-to-cart.js
+++ b/app/code/Magento/Catalog/view/frontend/web/js/catalog-add-to-cart.js
@@ -38,6 +38,11 @@ define([
         _bindSubmit: function () {
             var self = this;
 
+            if (this.element.data('catalog-addtocart-initialized')) {
+                return;
+            }
+
+            this.element.data('catalog-addtocart-initialized', 1);
             this.element.on('submit', function (e) {
                 e.preventDefault();
                 self.submitForm($(this));


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15409
### Description
catalogAddToCart widget initialize its functions for all suitable elements: 

- Template: https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Catalog/view/frontend/templates/product/list.phtml#L124
- Widget: https://github.com/magento/magento2/blob/2.2-develop/app/code/Magento/Catalog/view/frontend/web/js/catalog-add-to-cart.js#L29

This commit fixes this by additional `catalog-addtocart-initialized` flag.

### Manual testing scenarios
1. Navigate to the category with products.
2. Open developer console and execute the following script:

    ```js
    jQuery('footer').append('<script type="text/x-magento-init">{"[data-role=tocart-form], .form.map.checkout": {"catalogAddToCart": {}}}</script>');
    jQuery('footer').trigger('contentUpdated');
    ```

    > This scenario is a simplified case that may happen when some third-party widget loads ajax products listing on the page using standard listing template.

3. Open "Network" tab and press "Add to cart" on some product.
4. Two requests will be sent instead of one.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
